### PR TITLE
fix(disconnect): avoid trigger handleMuteCall after disconnected

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -220,7 +220,7 @@ export const App = (): JSX.Element => {
     if (shouldDisconnectAll) {
       await infinityClient.disconnectAll({})
     }
-    await infinityClient?.disconnect({})
+    await infinityClient.disconnect({})
     setConnectionState(ConnectionState.Disconnected)
   }
 
@@ -254,15 +254,14 @@ export const App = (): JSX.Element => {
       ? aniName
       : uuidv4()
 
+    // Add mute call listener
+    GenesysService.addMuteListener(onMuteCall)
+
     // Add on hold listener
-    GenesysService.addHoldListener(async (mute) => {
-      await onHoldVideo(mute)
-    })
+    GenesysService.addHoldListener(onHoldVideo)
 
     // Add end call listener
-    GenesysService.addEndCallListener(async (shouldDisconnectAll: boolean) => {
-      await onEndCall(shouldDisconnectAll)
-    })
+    GenesysService.addEndCallListener(onEndCall)
 
     // Add connect call listener
     GenesysService.addConnectCallListener(async () => {
@@ -270,11 +269,6 @@ export const App = (): JSX.Element => {
         setConnectionState(ConnectionState.Connecting)
         await initConference()
       }
-    })
-
-    // Add mute call listener
-    GenesysService.addMuteListener(async (mute) => {
-      await onMuteCall(mute)
     })
   }
 
@@ -557,9 +551,8 @@ export const App = (): JSX.Element => {
   }, [])
 
   useEffect(() => {
-    GenesysService.addHoldListener(async (mute) => {
-      await onHoldVideo(mute)
-    })
+    GenesysService.addHoldListener(onHoldVideo)
+    GenesysService.addEndCallListener(onEndCall)
 
     callSignals.onRemoteStream.add(handleRemoteStream)
     callSignals.onRemotePresentationStream.add(handleRemotePresentationStream)

--- a/src/genesys/genesysService.test.ts
+++ b/src/genesys/genesysService.test.ts
@@ -16,7 +16,7 @@ const customerMock = {
   purpose: 'customer',
   held: false,
   muted: false,
-  state: 'terminated',
+  state: 'connected',
   disconnectType: undefined,
   user: {
     id: 'f02618ce-1ae8-4429-bdb0-2d55f701a546'
@@ -283,6 +283,7 @@ describe('Genesys service', () => {
         accessToken
       )
       const mockHold = jest.fn()
+      GenesysService.addConnectCallListener(jest.fn())
       GenesysService.addMuteListener(jest.fn())
       GenesysService.addHoldListener(mockHold)
       callEvent.eventBody.participants[0].held = true
@@ -346,6 +347,7 @@ describe('Genesys service', () => {
         accessToken
       )
       const mockMute = jest.fn()
+      GenesysService.addConnectCallListener(jest.fn())
       GenesysService.addMuteListener(mockMute)
       callEvent.eventBody.participants[0].muted = true
       triggerEvent(callEvent)

--- a/src/genesys/genesysService.ts
+++ b/src/genesys/genesysService.ts
@@ -250,6 +250,11 @@ const callsCallback = (callEvent: CallEvent): void => {
       participant.state !== GenesysConnectionsState.Terminated
   )
 
+  if (agentParticipant == null || customerParticipant == null) {
+    console.warn('No agent or customer participant found in call event')
+    return
+  }
+
   // Disconnect event
   if (agentParticipant?.state === GenesysConnectionsState.Disconnected) {
     if (agentParticipant?.disconnectType === GenesysDisconnectType.CLIENT) {


### PR DESCRIPTION
After disconnected the iFrame with the agent app is still using the camera.

I discovered that the problem was provoked because after disconnected, genesys receive a second event and it tries to unmute. When the app does this, it calls to `navigator.mediaDevices.getUserMedia()` and obtain a new `mediaStream`.

The solution was to check if the agent and customer exists:

```
 if (agentParticipant == null || customerParticipant == null) {
    console.warn('No agent or customer participant found in call event')
    return
  }
  ```
  
  I also made some changes to simplify a bit the code.