### PR TITLE
fix(settings): correct the problem to change the camera

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,7 +159,7 @@ export const App = (): JSX.Element => {
     try {
       const device = await getInitialDevice()
       localStream = await navigator.mediaDevices.getUserMedia({
-        video: { deviceId: device?.deviceId }
+        video: { deviceId: { exact: device?.deviceId } }
       })
       processedStream = await getProcessedStream(localStream, effect)
       setDevice(device)
@@ -331,9 +331,7 @@ export const App = (): JSX.Element => {
         setProcessedStream(undefined)
       } else {
         const localStream = await navigator.mediaDevices.getUserMedia({
-          video: {
-            deviceId: device?.deviceId
-          }
+          video: { deviceId: { exact: device?.deviceId } }
         })
         const processedStream = await getProcessedStream(localStream, effect)
         setLocalStream(localStream)
@@ -423,7 +421,7 @@ export const App = (): JSX.Element => {
         track.stop()
       })
       newLocalStream = await navigator.mediaDevices.getUserMedia({
-        video: { deviceId: settings.device?.deviceId }
+        video: { deviceId: { exact: settings.device?.deviceId } }
       })
       setLocalStream(newLocalStream)
     }
@@ -457,7 +455,14 @@ export const App = (): JSX.Element => {
   }
 
   const getInitialDevice = async (): Promise<MediaDeviceInfoLike> => {
+    const localStream = await navigator.mediaDevices.getUserMedia({
+      video: true
+    })
     const devices = await navigator.mediaDevices.enumerateDevices()
+    localStream.getTracks().forEach((track) => {
+      track.stop()
+    })
+
     const videoDevices = devices.filter(
       (device) => device.kind === 'videoinput'
     )

--- a/src/settings-panel/SettingsPanel.tsx
+++ b/src/settings-panel/SettingsPanel.tsx
@@ -48,7 +48,7 @@ export const SettingsPanel = (props: SettingsPanelProps): JSX.Element => {
     const device = devices.find((device) => device.deviceId === deviceId)
     setDevice(device)
     const localStream = await navigator.mediaDevices.getUserMedia({
-      video: { deviceId }
+      video: { deviceId: { exact: deviceId } }
     })
     setLocalStream(localStream)
     handleChangeEffect(effect, localStream).catch(console.error)
@@ -98,7 +98,7 @@ export const SettingsPanel = (props: SettingsPanelProps): JSX.Element => {
       if (device != null) {
         setDevice(device)
         const localStream = await navigator.mediaDevices.getUserMedia({
-          video: { deviceId: device.deviceId }
+          video: { deviceId: { exact: device.deviceId } }
         })
         handleChangeEffect(effect, localStream).catch(console.error)
         setLocalStream(localStream)
@@ -142,7 +142,8 @@ export const SettingsPanel = (props: SettingsPanelProps): JSX.Element => {
         devices={createIndexedDevices(devices)}
         isDisabled={false}
         label={''}
-        onDeviceChange={(deviceId) => {
+        onDeviceChange={(id) => {
+          const [deviceId] = id.split(':')
           handleChangeDevice(deviceId).catch(console.error)
         }}
         iconType={IconTypes.IconVideoOn}


### PR DESCRIPTION
I checked it with Chrome and Firefox. We had three problems:

- The `<DeviceSelect>` component has property `onDeviceChange` . Before it received the `deviceId`, but now the callback receives the `id` that has the structure `deviceId:kind` (e.g. 1eb157fe9e809411c307386aed1f702ef24b7c7a854d7a31fabc7b701e9b2373:videoinput).
- We didn't used the `exact` constraints for the `deviceId`, so the selection in the browser wasn't overriden.
- We need to request the access to the camera before calling `enumerateDevices()`. So before calling this function we need to do:
```
const localStream = await navigator.mediaDevices.getUserMedia({
  video: true
})
```

If we don't call `getUserMedia`, we won't be able to obtain any device info.